### PR TITLE
Fix expression that gives the left offset for the thumb

### DIFF
--- a/scrubber.js
+++ b/scrubber.js
@@ -50,7 +50,9 @@ ScrubberView.prototype.createDOM = function () {
 };
 
 ScrubberView.prototype.redraw = function () {
-  var frac = this.value()/(this.max() - this.min());
+  // var frac = this.value()/(this.max() - this.min());  I don't think this gives the right fraction
+  // For example, if you had min: 5, max: 15, value: 10, this would give you 100%, but should be 50%.
+  var frac = (this.value() - this.min())/(this.max() - this.min());
   this.thumb.style.left = frac*100 + '%';
 };
 


### PR DESCRIPTION
This was doing wonky things when I tried to change the min value.
