### PR TITLE
Tune event listeners

### DIFF
--- a/scrubber.js
+++ b/scrubber.js
@@ -133,8 +133,8 @@ ScrubberView.prototype.attachListeners = function ()  {
   };
 
   var stop = function () {
-    document.removeEventListener('mouseup', stop, true);
-    document.removeEventListener('touchend', stop, true);
+    document.removeEventListener('mouseup', stop);
+    document.removeEventListener('touchend', stop);
     mousedown = false;
     cachedLeft = undefined;
     cachedWidth = undefined;

--- a/scrubber.js
+++ b/scrubber.js
@@ -111,7 +111,10 @@ ScrubberView.prototype.attachListeners = function ()  {
   var start = function (evt) {
     evt.preventDefault();
     self.onScrubStart(self.value());
-
+    
+    document.addEventListener('mouseup', stop);
+    document.addEventListener('touchend', stop);
+    
     mousedown = true;
     var rect = self.elt.getBoundingClientRect();
     // NOTE: page[X|Y]Offset and the width and height
@@ -130,6 +133,8 @@ ScrubberView.prototype.attachListeners = function ()  {
   };
 
   var stop = function () {
+    document.removeEventListener('mouseup', stop, true);
+    document.removeEventListener('touchend', stop, true);
     mousedown = false;
     cachedLeft = undefined;
     cachedWidth = undefined;
@@ -187,7 +192,4 @@ ScrubberView.prototype.attachListeners = function ()  {
     else
       setValueFromPageY(evt.changedTouches[0].pageY);
   });
-
-  document.addEventListener('mouseup', stop);
-  document.addEventListener('touchend', stop);
 };


### PR DESCRIPTION
Adjust event listeners so the ones assigned to the document only fire after the scrubber has started. Before the scrub change & end would fire on any mouse click on the document (see the console on http://interactive.nydailynews.com/map/school-shootings/before/ ), with this change the scrub change & end only fires on mouse clicks *after* the scrubber has been started (see the console on http://interactive.nydailynews.com/map/school-shootings/ ).